### PR TITLE
Add chumpy installation to smplx build recipe

### DIFF
--- a/smplx/smplx_with_chumpy.def
+++ b/smplx/smplx_with_chumpy.def
@@ -1,0 +1,85 @@
+# Use cuda container from nvcr.io is the current only solution to make pyrender work.
+# Note this container should be used with screen, currently is done by Thinlinc to Alvis.
+Bootstrap: docker
+From: nvcr.io/nvidia/cuda:11.7.1-devel-ubuntu20.04
+%post
+export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6+PTX"
+apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential cmake git wget vim ffmpeg software-properties-common \
+        python3-setuptools python3-dev python3-pip python3-tk cython \
+        libx264-dev sudo pkg-config libyaml-dev libopencv-dev \
+        libgoogle-glog-dev libboost-all-dev libhdf5-dev libatlas-base-dev \
+        libopencv-dev protobuf-compiler libgoogle-glog-dev libboost-all-dev \
+        libhdf5-dev libatlas-base-dev libprotobuf-dev zip unzip file ninja-build p7zip-full p7zip-rar \
+        freeglut3 freeglut3-dev libegl1 libboost-dev
+
+# Pyrender, no need to install mesa
+mkdir  /workspace
+cd /workspace
+pip install numpy==1.23.0
+pip install torch==1.13.0+cu117 torchvision==0.14.0+cu117 torchaudio==0.13.0 --extra-index-url https://download.pytorch.org/whl/cu117
+git clone https://github.com/mmatl/pyopengl.git
+pip install ./pyopengl/
+# Install OpenGL_accelerate module
+cd pyopengl
+pip install ./accelerate/
+# Fix helper_math.h not found error
+cd /workspace
+git clone https://github.com/NVIDIA/cuda-samples.git
+export CUDA_SAMPLES_INC=/workspace/cuda-samples/Common/
+# Install smplx
+cd /workspace
+pip install smplx[all]
+git clone https://github.com/vchoutas/smplx && cd smplx && python3 setup.py install
+pip install -r requirements.txt
+# Install mesh
+cd /workspace
+git clone https://github.com/MPI-IS/mesh.git
+cd mesh
+BOOST_INCLUDE_DIRS=/usr/include/boost make all
+# Install the Torch Trust Region optimizer
+cd /workspace
+git clone https://github.com/vchoutas/torch-trust-ncg.git
+cd torch-trust-ncg
+pip install .
+#python3 setup.py install
+pip install opencv-python==4.5.5.64
+pip install loguru open3d omegaconf 
+cd /workspace/smplx
+
+# Add mask_ids_fname to config file
+sed -i "5s/.*/mask_ids_fname: 'transfer_data\/smplx_mask_ids.npy'/" /workspace/smplx/config_files/smplx2smpl.yaml
+mkdir -p transfer_data/body_models/smpl
+# Download model correspondences for model tranfer
+wget -O model_transfer.zip https://kth-my.sharepoint.com/:u:/g/personal/qyuan_ug_kth_se/EeQko1VAvB5LsTwd1UsSRvEBCmq55U9wTc61mKCi1ufc2Q?Download=1
+unzip model_transfer.zip -d transfer_data/
+# Download sample data
+wget -O sample_transfer_data.zip https://kth-my.sharepoint.com/:u:/g/personal/qyuan_ug_kth_se/EeBIKSzK0-9Dkita7oAX6tABE6W8CTeHyOlm3VVNA_Xi2A?Download=1
+unzip sample_transfer_data.zip #-d transfer_data/
+# Download the SMPLX model
+wget -O models_smplx_v1_1.zip https://kth-my.sharepoint.com/:u:/g/personal/qyuan_ug_kth_se/Ed80j693XelDlu_Re0Pgm9UBjSTfhnjKaZ9gtT3pp58LUA?Download=1
+unzip models_smplx_v1_1.zip
+mv models/smplx transfer_data/body_models/
+rm -r models
+rm models_smplx_v1_1.zip
+#Download SMPL
+wget -O SMPL_python_v.1.1.0.zip https://kth-my.sharepoint.com/:u:/g/personal/qyuan_ug_kth_se/Ed4cb9at1jFCrWsbzGXsE14BPORApYlsJrME3xJm8NW1UQ?Download=1
+unzip SMPL_python_v.1.1.0.zip
+mv SMPL_python_v.1.1.0/smpl/models/basicmodel_f_lbs_10_207_0_v1.1.0.pkl transfer_data/body_models/smpl/SMPL_FEMALE.pkl
+mv SMPL_python_v.1.1.0/smpl/models/basicmodel_neutral_lbs_10_207_0_v1.1.0.pkl transfer_data/body_models/smpl/SMPL_NEUTRAL.pkl
+mv SMPL_python_v.1.1.0/smpl/models/basicmodel_m_lbs_10_207_0_v1.1.0.pkl transfer_data/body_models/smpl/SMPL_MALE.pkl
+rm -r SMPL_python_v.1.1.0
+rm SMPL_python_v.1.1.0.zip
+
+#Structure transfer_data/body_models/smpl/SMPL_NEUTRAL.pkl
+pip install numpy==1.23
+
+#Install chumpy
+pip install --force-reinstall pip==19
+pip install chumpy
+
+%environment
+    export PATH=$PATH:/usr/local/bin
+    export CUDA_SAMPLES_INC=/workspace/cuda-samples/Common/
+    export PYTHONPATH=$PYTHONPATH:/usr/lib/python3.8/site-packages/


### PR DESCRIPTION
Here pip isn't upgraded back to its original version after installing chumpy, I have no clue if it should be done but at least this way it looks like the conversion from smplx to smpl works for me